### PR TITLE
upgrade slurm images to 23.02.7 and 23.11.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Running the slurm-client is as follows:
 
 ```
 docker run -it --rm --entrypoint=bash -v /tmp/munge.key:/tmp/munge/munge.key -v /tmp/slurm.conf:/etc/slurm/slurm.conf -v /tmp/slurmdbd.conf:/etc/slurm/slurmdbd.conf -v /tmp/jwt_hs256.key:/etc/slurm/jwt_hs256.key --network=host $REPOSITORY/slurm-client:$VERSION
+
+# Once docker container starts, start munge service
+sh start-slurm-client.sh
 ```
 
 ### Troubleshooting

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ docker build --build-arg VERSION=$VERSION -f src/docker/slurm-single-node -t $RE
 To simply run the slurm-single-node docker container, execute the following command:
 
 ```
+export REPOSITORY=hokiegeek2
+export VERSION=23.11.4
+
 docker run -it --rm --network=host --privileged $REPOSITORY/slurm-single-node:$VERSION
 ```
 
@@ -29,16 +32,19 @@ Note: running the docker container in privileged mode is required to run slurmre
 In order to perform any integration testing with applications outside of the slurm-single-node, a munge.key used in the external app must be mounted into the docker container. Accordingly, to mount a munge.key and start the slurm-single-node docker container, execute the following command:
 
 ```
-docker run -it --rm --network=host -v $PWD/munge.key:/tmp/munge.key hokiegeek2/slurm-single-node
+export REPOSITORY=hokiegeek2
+export VERSION=23.11.4
+
+docker run -it --rm --network=host -v $PWD/munge.key:/tmp/munge.key $REPOSITORY/slurm-single-node:$VERSION
 ```
 
 Successful startup of slurm-single-node looks like this:
 
 ![](https://user-images.githubusercontent.com/10785153/126529217-e8df432b-c925-4155-af37-d00e9205cd16.png)
 
-### slurm-lient Docker
+### slurm-client Docker
 
-The slurm-client Dockerfile serves as a base Docker image to build slurm client images such as slurmrestd where the node is neither the slurm controller (slurmctld) or slurm worker (slurmd)
+The [slurm-client](https://github.com/hokiegeek2/slurm-cloud-integration/blob/master/src/docker/slurm-client) Dockerfile serves as a base Docker image to build slurm client images such as slurmrestd where the node is neither a slurm controller (slurmctld) nor a slurm worker (slurmd)
 
 Building the slurm-client is as follows:
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,15 @@ The [slurm-single-node](https://github.com/hokiegeek2/slurm-cloud-integration/bl
 The slurm-single-node Docker image is built from the project root directory as follows:
 
 ```
-docker build -f src/docker/slurm-single-node -t hokiegeek2/slurm-single-node:$VERSION .
+export REPOSITORY=hokiegeek2
+export VERSION=23.11.4
+
+docker build --build-arg VERSION=$VERSION -f src/docker/slurm-single-node -t $REPOSITORY/slurm-single-node:$VERSION .
 ```
 To simply run the slurm-single-node docker container, execute the following command:
 
 ```
-docker run -it --rm --network=host --privileged hokiegeek2/slurm-single-node
+docker run -it --rm --network=host --privileged $REPOSITORY/slurm-single-node:$VERSION
 ```
 
 Note: running the docker container in privileged mode is required to run slurmrestd
@@ -33,20 +36,23 @@ Successful startup of slurm-single-node looks like this:
 
 ![](https://user-images.githubusercontent.com/10785153/126529217-e8df432b-c925-4155-af37-d00e9205cd16.png)
 
-### Slurm Client Docker
+### slurm-lient Docker
 
-The slurm-client-docker serves as a base Docker image to build slurm client images such as slurmrestd where the node is neither the slurm controller (slurmctld) or slurm worker (slurmd)
+The slurm-client Dockerfile serves as a base Docker image to build slurm client images such as slurmrestd where the node is neither the slurm controller (slurmctld) or slurm worker (slurmd)
 
-Building the slurm-client-docker is as follows:
-
-```
-docker build -f src/docker/slurm-client-docker -t hokiegeek2/slurm-client-docker .
-```
-
-Running the slurm-client-docker is as follows:
+Building the slurm-client is as follows:
 
 ```
-docker run -it --rm --entrypoint=bash -v /tmp/munge.key:/tmp/munge/munge.key -v /tmp/slurm.conf:/etc/slurm/slurm.conf -v /tmp/slurmdbd.conf:/etc/slurm/slurmdbd.conf -v /tmp/jwt_hs256.key:/etc/slurm/jwt_hs256.key --network=host hokiegeek2/slurm-client-docker
+export REPOSITORY=hokiegeek2
+export VERSION=23.11.4
+
+docker build --build-arg VERSION=$VERSION -f src/docker/slurm-client -t $REPOSITORY/slurm-client:$VERSION .
+```
+
+Running the slurm-client is as follows:
+
+```
+docker run -it --rm --entrypoint=bash -v /tmp/munge.key:/tmp/munge/munge.key -v /tmp/slurm.conf:/etc/slurm/slurm.conf -v /tmp/slurmdbd.conf:/etc/slurm/slurmdbd.conf -v /tmp/jwt_hs256.key:/etc/slurm/jwt_hs256.key --network=host $REPOSITORY/slurm-client:$VERSION
 ```
 
 ### Troubleshooting

--- a/src/conf/single-node-slurm.conf
+++ b/src/conf/single-node-slurm.conf
@@ -54,7 +54,7 @@ Waittime=0
 # SCHEDULING
 SchedulerType=sched/backfill
 #SchedulerAuth=
-SelectType=select/cons_res
+SelectType=select/cons_tres
 SelectTypeParameters=CR_Core_Memory,CR_CORE_DEFAULT_DIST_BLOCK,CR_ONE_TASK_PER_CORE
 #FastSchedule=1
 #PriorityType=priority/multifactor

--- a/src/docker/slurm-client
+++ b/src/docker/slurm-client
@@ -1,12 +1,15 @@
-FROM ubuntu:18.04 as slurm_build
+FROM ubuntu:22.04 as slurm_build
 
 CMD ["/bin/bash"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+ARG VERSION=${VERSION}
+ENV VERSION=${VERSION}
+
 # Install all base dependencies
-RUN apt-get update && apt install sudo git gcc make ruby ruby-dev python3 \
-    libpam0g-dev libmariadb-client-lgpl-dev libmysqlclient-dev wget vim curl -y
+RUN apt-get update && apt install sudo git gcc make ruby ruby-dev python3 bzip2 \
+    libpam0g-dev mariadb-client libmysqlclient-dev wget vim curl libtool -y
 
 # Install gem needed for dpkg
 RUN gem install fpm
@@ -20,9 +23,9 @@ RUN apt-get install libhdf5-serial-dev hdf5-tools -y
 RUN mkdir /storage
 WORKDIR /storage
 
-RUN wget https://download.schedmd.com/slurm/slurm-21.08.5.tar.bz2
-RUN tar xf slurm-21.08.5.tar.bz2
-WORKDIR /storage/slurm-21.08.5
+RUN wget https://download.schedmd.com/slurm/slurm-$VERSION.tar.bz2 && \
+    tar xvf slurm-$VERSION.tar.bz2
+WORKDIR /storage/slurm-$VERSION
 
 RUN ./configure --prefix=/storage/slurm-build --sysconfdir=/etc/slurm --enable-pam \
     --with-pam_dir=/lib/x86_64-linux-gnu/security/ --without-shared-libslurm 
@@ -32,16 +35,19 @@ RUN make contrib
 RUN make install
 
 WORKDIR /storage
-RUN fpm -s dir -t deb -v 1.0 -n slurm-21.08.5 --prefix=/usr -C /storage/slurm-build .
+RUN fpm -s dir -t deb -v 1.0 -n slurm-$VERSION --prefix=/usr -C /storage/slurm-build .
 
-FROM ubuntu:18.04
+FROM ubuntu:22.04
+
+ARG VERSION=${VERSION}
+ENV VERSION=${VERSION}
 
 # extract and install slurm
 RUN mkdir /storage
 WORKDIR /storage
 COPY --from=slurm_build /storage/slurm-build /storage/slurm-build
-COPY --from=slurm_build /storage/slurm-21.08.5_1.0_amd64.deb ./
-RUN dpkg -i slurm-21.08.5_1.0_amd64.deb && rm -rf slurm-21.08.5_1.0_amd64.deb
+COPY --from=slurm_build /storage/slurm-${VERSION}_1.0_amd64.deb ./
+RUN dpkg -i slurm-${VERSION}_1.0_amd64.deb && rm -rf slurm-${VERSION}_1.0_amd64.deb
 
 ## Install munge
 RUN apt-get update && apt-get install libmunge-dev libmunge2 munge -y

--- a/src/docker/slurm-single-node
+++ b/src/docker/slurm-single-node
@@ -1,5 +1,8 @@
 FROM ubuntu:22.04
 
+ARG VERSION=${VERSION}
+ENV VERSION=${VERSION}
+
 RUN apt update && apt-get update && apt install sudo git gcc make ruby \
         ruby-dev python3 libpam0g-dev libmysqlclient-dev mariadb-client \
         mariadb-server wget vim curl -y
@@ -21,11 +24,15 @@ RUN autoreconf --force --install && \
 RUN useradd -m -u 1004 slurm && \
     useradd slurmrestd
 
+RUN echo $VERSION
+
+RUN export SLURM_VERSION=$VERSION
+
 RUN mkdir /storage
 WORKDIR /storage
-RUN wget https://download.schedmd.com/slurm/slurm-22.05.3.tar.bz2 && \
-    tar xvf slurm-22.05.3.tar.bz2 && \
-    cd slurm-22.05.3 && \
+RUN wget https://download.schedmd.com/slurm/slurm-$VERSION.tar.bz2 && \
+    tar xvf slurm-$VERSION.tar.bz2 && \
+    cd slurm-$VERSION && \
     ./configure --prefix=/storage/slurm-build --sysconfdir=/etc/slurm --enable-pam \
     --with-pam_dir=/lib/x86_64-linux-gnu/security/ --with-http-parser=/usr/ \
     --with-yaml=/usr/ --with-jwt=/usr/ && \
@@ -34,8 +41,8 @@ RUN wget https://download.schedmd.com/slurm/slurm-22.05.3.tar.bz2 && \
     make install 
 
 WORKDIR /storage
-RUN fpm -s dir -t deb -v 1.0 -n slurm-22.05.3 --prefix=/usr -C /storage/slurm-build . && \
-    dpkg -i slurm-22.05.3_1.0_amd64.deb
+RUN fpm -s dir -t deb -v 1.0 -n slurm-$SLURM_VERSION --prefix=/usr -C /storage/slurm-build .
+RUN dpkg -i slurm-$VERSION_1.0_amd64.deb
 
 # Make runtime and conf directories
 RUN mkdir -p /etc/slurm /etc/slurm/prolog.d /etc/slurm/epilog.d /var/spool/slurm/ctld \
@@ -72,4 +79,4 @@ RUN chown slurm:slurm /etc/slurm/slurmdbd.conf
 RUN echo "/usr/lib/slurm" | sudo tee /etc/ld.so.conf && \
          ldconfig
 
-ENTRYPOINT sh start-slurm-cluster.sh
+ENTRYPOINT sudo sh start-slurm-cluster.sh

--- a/src/docker/slurm-single-node
+++ b/src/docker/slurm-single-node
@@ -26,8 +26,6 @@ RUN useradd -m -u 1004 slurm && \
 
 RUN echo $VERSION
 
-RUN export SLURM_VERSION=$VERSION
-
 RUN mkdir /storage
 WORKDIR /storage
 RUN wget https://download.schedmd.com/slurm/slurm-$VERSION.tar.bz2 && \
@@ -41,8 +39,8 @@ RUN wget https://download.schedmd.com/slurm/slurm-$VERSION.tar.bz2 && \
     make install 
 
 WORKDIR /storage
-RUN fpm -s dir -t deb -v 1.0 -n slurm-$SLURM_VERSION --prefix=/usr -C /storage/slurm-build .
-RUN dpkg -i slurm-$VERSION_1.0_amd64.deb
+RUN fpm -s dir -t deb -v 1.0 -n slurm-$VERSION --prefix=/usr -C /storage/slurm-build .
+RUN dpkg -i slurm-${VERSION}_1.0_amd64.deb
 
 # Make runtime and conf directories
 RUN mkdir -p /etc/slurm /etc/slurm/prolog.d /etc/slurm/epilog.d /var/spool/slurm/ctld \


### PR DESCRIPTION
Closes #13 

This PR does the following:

1. Makes slurm-single-node and slurm-client configurable for slurm version
2. Upgrades slurm-single-node and slurm-client to Slurm 23.02.7 and 23.11.4
3. Updates README